### PR TITLE
Fix missing alt attribute in service image

### DIFF
--- a/pages/services.js
+++ b/pages/services.js
@@ -48,7 +48,7 @@ export default function services() {
               </div>
 
               <div className="flex justify-center">
-                <Image src="/Kefka.png" width={300} height={300} />
+                <Image src="/Kefka.png" alt="Kefka" width={300} height={300} />
               </div>
 
               {/* Services List */}


### PR DESCRIPTION
## Summary
- ensure images on services page include alt text

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685197fe6c3483278ba8e3938566a2d4