### PR TITLE
Add award animation and content

### DIFF
--- a/components/animations/AwardIcon.jsx
+++ b/components/animations/AwardIcon.jsx
@@ -1,0 +1,17 @@
+"use client";
+import React from "react";
+import { motion } from "framer-motion";
+import { Award } from "lucide-react";
+
+export default function AwardIcon({ size = 80 }) {
+  return (
+    <motion.div
+      className="text-[#D0FE1D]"
+      initial={{ rotate: 0 }}
+      animate={{ rotate: 360 }}
+      transition={{ repeat: Infinity, ease: "linear", duration: 8 }}
+    >
+      <Award size={size} strokeWidth={1.5} />
+    </motion.div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,9 @@ import ScrollDown from "@/public/svg/ScrollDown"
 import { VelocityScroll } from "@/components/magicui/scroll-based-velocity"
 import { motion } from "framer-motion"
 import AdvancedNavbar from "@/components/navbar/Navbar"
+import AwardIcon from "@/components/animations/AwardIcon"
+import { MagicCard } from "@/components/magicui/magic-card"
+import BlurFade from "@/components/magicui/blur-fade"
 
 export default function ResponsiveWhatsUpDashboard() {
   const [windowWidth, setWindowWidth] = useState(
@@ -87,8 +90,56 @@ export default function ResponsiveWhatsUpDashboard() {
           className="font-display text-center text-4xl font-bold tracking-[-0.02em] drop-shadow-sm md:text-9xl md:leading-[5rem]"
         />
       </section>
-      <section className="min-h-screen flex items-center justify-center p-4">
-        <h1 className="text-4xl lg:text-9xl">Will add projects soon...</h1>
+
+      <section className="py-24 flex flex-col items-center gap-8">
+        <AwardIcon size={120} />
+        <BlurFade inView>
+          <h2 className="text-4xl md:text-6xl font-bold mb-4 text-center">
+            Award-Winning Animations
+          </h2>
+        </BlurFade>
+        <BlurFade inView delay={0.1}>
+          <p className="max-w-2xl text-center text-lg md:text-xl">
+            We craft smooth and immersive experiences that captivate users.
+          </p>
+        </BlurFade>
+      </section>
+
+      <section className="min-h-screen flex flex-col items-center justify-center p-4 gap-8">
+        <h2 className="text-4xl md:text-6xl font-bold mb-6">Featured Projects</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-4xl">
+          <MagicCard className="p-6">
+            <h3 className="text-xl font-bold mb-2">Project Alpha</h3>
+            <p>Innovative design meets seamless performance.</p>
+          </MagicCard>
+          <MagicCard className="p-6">
+            <h3 className="text-xl font-bold mb-2">Project Beta</h3>
+            <p>Interactive experiences built with cutting-edge tech.</p>
+          </MagicCard>
+          <MagicCard className="p-6">
+            <h3 className="text-xl font-bold mb-2">Project Gamma</h3>
+            <p>Engaging, responsive, and user-friendly.</p>
+          </MagicCard>
+          <MagicCard className="p-6">
+            <h3 className="text-xl font-bold mb-2">Project Delta</h3>
+            <p>Sleek interfaces with robust architecture.</p>
+          </MagicCard>
+        </div>
+      </section>
+
+      <section className="py-24 flex flex-col items-center gap-6">
+        <BlurFade inView>
+          <h2 className="text-4xl md:text-6xl font-bold mb-4 text-center">
+            About Us
+          </h2>
+        </BlurFade>
+        <BlurFade inView delay={0.1}>
+          <p className="max-w-3xl text-center text-lg md:text-xl">
+            We are a team of creatives passionate about delivering memorable
+            digital experiences. Our goal is to combine modern technologies
+            with refined design to help brands stand out.
+          </p>
+        </BlurFade>
       </section>
     </main>
   )


### PR DESCRIPTION
## Summary
- add an animated Award icon component
- expand homepage with animated sections and project cards

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685198f5c0388327885edc49f6c8f378